### PR TITLE
Fix directory name typo

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ Build instructions (Ubuntu 14.04):
 * git clone https://github.com/Nooskewl/monster-rpg-3.git
 * cd tgui3 && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && make
 * cd Nooskewl_Engine && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DUSER_INCLUDE_PATH=/path/to/tgui3/include -DUSER_LIBRARY_PATH=/path/to/tgui3/build && make
-* cd monster-rpg-2 && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DUSER_INCLUDE_PATH="/path/to/tgui3/include;/path/to/Nooskewl_Engine/include" -DUSER_LIBRARY_PATH="/path/to/tgui3/build;/path/to/Nooskewl_Engine/build" && make
+* cd monster-rpg-3 && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DUSER_INCLUDE_PATH="/path/to/tgui3/include;/path/to/Nooskewl_Engine/include" -DUSER_LIBRARY_PATH="/path/to/tgui3/build;/path/to/Nooskewl_Engine/build" && make
 * cd ~ && mkdir mo3
 * cp /path/to/tgui3/build/libtgui3.so /path/to/Nooskewl_Engine/build/libNooskewl_Engine.so /path/to/Nooskewl_Engine/build/Nooskewl_Runner /path/to/monster-rpg-3/build/libMonsterRPG3.so mo3
 * copy MonsterRPG3.cpa to mo3


### PR DESCRIPTION
Build instruction calls for moving into monster-rpg-2 directory, but
there exists no directory by that name. The correct directory name
should be monster-rpg-3, as instructions call for cloning
monster-rpg-3, not monster-rpg-2.